### PR TITLE
1.0 patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: erlang
-before_install:
-  - wget https://s3.amazonaws.com/rebar3/rebar3
-  - chmod +x rebar3
+install: true
 env:
   - PATH=".:$PATH"
+before_script:
+  - wget https://s3.amazonaws.com/rebar3/rebar3
+  - chmod +x rebar3
 script:
   - make check
 otp_release:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: erlang
-before_script: "make get-lfetool"
-script: "make check"
-notifications:
-  #irc: "irc.freenode.org#YOUR-PROJECT-CHANNEL"
-  recipients:
-    #- YOU@YOUR.DOMAIN
+before_install:
+  - wget https://s3.amazonaws.com/rebar3/rebar3
+  - chmod +x rebar3
+env:
+  - PATH=".:$PATH"
+script:
+  - make check
 otp_release:
-  - 17.1
-  - R16B03
+  - 18.2
+  - 17.5
+  - R16B03-1
   - R15B03

--- a/lfe.config
+++ b/lfe.config
@@ -2,7 +2,7 @@
   (#(meta
      (#(name kla)
       #(description "An LFE Wrapper Library used to Dress Up Erlang Libraries in a Lispy Costume")
-      #(version "0.6.0")
+      #(version "0.6.1")
       #(keywords ("LFE" "Lisp" "Library" "Utility"))
       #(maintainers
         ((#(name "Duncan McGreggor") #(email "oubiwann@gmail.com"))))

--- a/lfe.config
+++ b/lfe.config
@@ -2,7 +2,7 @@
   (#(meta
      (#(name kla)
       #(description "An LFE Wrapper Library used to Dress Up Erlang Libraries in a Lispy Costume")
-      #(version "0.6.1")
+      #(version "0.6.2")
       #(keywords ("LFE" "Lisp" "Library" "Utility"))
       #(maintainers
         ((#(name "Duncan McGreggor") #(email "oubiwann@gmail.com"))))

--- a/rebar.config
+++ b/rebar.config
@@ -17,3 +17,9 @@
 {provider_hooks, [
    {pre, [{compile, {lfe, compile}}]}
   ]}.
+
+{profiles, [
+   {test,
+    [{deps,
+      [{ltest, {git, "https://github.com/lfex/ltest.git", {tag, "0.7.1"}}}]}]}
+  ]}.

--- a/src/kla.app.src
+++ b/src/kla.app.src
@@ -5,7 +5,7 @@
   {description, "An LFE Wrapper Library used to Dress Up Erlang Libraries in a Lispy Costume"},
 
   %% The version of the application
-  {vsn, "0.6.1"},
+  {vsn, "0.6.2"},
 
   %% All modules used by the application.
   {modules,

--- a/src/kla.app.src
+++ b/src/kla.app.src
@@ -5,7 +5,7 @@
   {description, "An LFE Wrapper Library used to Dress Up Erlang Libraries in a Lispy Costume"},
 
   %% The version of the application
-  {vsn, "0.6.0"},
+  {vsn, "0.6.1"},
 
   %% All modules used by the application.
   {modules,

--- a/src/kla.lfe
+++ b/src/kla.lfe
@@ -51,7 +51,7 @@
      (filter-funcs funcs))))
 
 (defun filter-funcs (funcs)
-  (let ((skips '(module_info)))
+  (let ((skips '(LFE-EXPAND-EXPORTED-MACRO module_info)))
     (lists:filter
       (match-lambda
         ((`#(,func ,_)) (not (lists:member func skips))))

--- a/src/kla.lfe
+++ b/src/kla.lfe
@@ -51,7 +51,9 @@
      (filter-funcs funcs))))
 
 (defun filter-funcs (funcs)
-  (let ((skips '(LFE-EXPAND-EXPORTED-MACRO module_info)))
+  (let ((skips '($handle_undefined_function
+                 LFE-EXPAND-EXPORTED-MACRO
+                 module_info)))
     (lists:filter
       (match-lambda
         ((`#(,func ,_)) (not (lists:member func skips))))


### PR DESCRIPTION
Add [ltest](https://github.com/lfex/ltest) as dependency under the `test` profile so `rebar3 eunit` can succeed.

Add `LFE-EXPAND-EXPORTED-MACRO` to the list of functions to skip in `kla:filter-funcs/1`. Without that the build was failing with a `{redef_fun,{'LFE-EXPAND-EXPORTED-MACRO',3}}` error.

This patch seems to solve the build problems wrt [clj](https://github.com/lfex/clj) and [lutil](https://github.com/lfex/lutil), too. :tada:

Bump the version to `0.6.1` for good measure.
