### PR TITLE
Clean up .travis.yml and Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: erlang
+sudo: false
 install: true
-env:
-  - PATH=".:$PATH"
+env: PATH=".:$PATH"
 before_script:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3
-  - sudo echo "#!/usr/bin/env bash" > `which rebar`
-script:
-  - make check
+script: make check
 otp_release:
   - 18.2
   - 17.5

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ compile:
 	rebar3 compile
 
 check:
-	@rebar3 as test eunit
+	@rebar3 eunit
 
 repl:
 	@rebar3 as dev compile


### PR DESCRIPTION
Mostly cosmetic.
- Inline `make check` and `env: ...` in `.travis.yml`
- Remove redundant `as test` in `Makefile`
- Route the build to [container-based infrastructure](https://docs.travis-ci.com/user/workers/container-based-infrastructure/), i.e. `sudo: false`
